### PR TITLE
Handle updated PRM URLs with language support (Version 1.3.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.backup
 *.log
+.vscode/settings.json

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "League of Legends Scouting Helper",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "An extention to help you scout your opponents both on Prime League as well as for Uni Liga germany.",
   "permissions": [],
   "icons": {
@@ -11,11 +11,11 @@
   "content_scripts": [ 
     {
    "js": ["premierTourHelperLib.js","teamPage.js"],
-   "matches": [ "*://www.primeleague.gg/leagues/prm/**/teams/*" ]
+   "matches": [ "*://www.primeleague.gg/**/leagues/prm/**/teams/*" ]
   },
   {
     "js": ["premierTourHelperLib.js","matchPage.js"],
-    "matches": [ "*://www.primeleague.gg/leagues/matches/*" ]
+    "matches": [ "*://www.primeleague.gg/**/leagues/matches/*" ]
    },
    {
     "js": ["premierTourHelperLib.js","toornamentMatchPage.js"],


### PR DESCRIPTION
The PRM URLs have been updated to include a language-specific path, such as:
- www.primeleague.gg/de/leagues/...
- www.primeleague.gg/en/leagues/...

This replaces the previous format:
- www.primeleague.gg/leagues/...

Changes made:
- Updated the manifest file to account for the new URL structure